### PR TITLE
Allow Models Builder to have correct type

### DIFF
--- a/src/Our.Umbraco.OpeningHours/Converters/OpeningHoursValueConverter.cs
+++ b/src/Our.Umbraco.OpeningHours/Converters/OpeningHoursValueConverter.cs
@@ -3,9 +3,11 @@ using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
+using Our.Umbraco.OpeningHours.Model;
 
 namespace Our.Umbraco.OpeningHours.Converters
 {
+    [PropertyValueType(typeof(OpeningHours))]
     [PropertyValueCache(PropertyCacheValue.All, PropertyCacheLevel.Content)]
     public class OpeningHoursValueConverter : PropertyValueConverterBase
     {


### PR DESCRIPTION
Without the added attribute the ModelsBuilder just creates a property of type 'object'