### PR TITLE
Add config option to hide property label and description

### DIFF
--- a/src/Our.Umbraco.OpeningHours/App_Plugins/OpeningHours/Controllers/OpeningHoursEditor.js
+++ b/src/Our.Umbraco.OpeningHours/App_Plugins/OpeningHours/Controllers/OpeningHoursEditor.js
@@ -8,5 +8,7 @@
     // Ensure properties of the configuration object
     $scope.model.config.hideWeekdays = parseBoolean($scope.model.config.hideWeekdays);
     $scope.model.config.hideHolidays = parseBoolean($scope.model.config.hideHolidays);
-
+    
+    // Option to hide property label
+    $scope.model.hideLabel = parseBoolean($scope.model.config.hideLabel);
 }); 

--- a/src/Our.Umbraco.OpeningHours/App_Plugins/OpeningHours/package.manifest
+++ b/src/Our.Umbraco.OpeningHours/App_Plugins/OpeningHours/package.manifest
@@ -40,6 +40,12 @@
                         "description": "The maximum amount of time slots that can be added (0 = unlimited).",
                         "key": "maxTimeSlots",
                         "view": "number"
+                    },
+                    {
+                        "label": "Hide label",
+                        "description": "Set whether to hide the editor label and take up the full width of the editing area.",
+                        "key": "hideLabel",
+                        "view": "boolean"
                     }
                 ]
             }


### PR DESCRIPTION
Issue: https://github.com/bomortensen/Our.Umbraco.OpeningHours/issues/18

Useful to hide label e.g. if used inside Nested Content or Archetype.