### PR TITLE
Solves #37 - Support for Umbraco 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ artifacts/
 src/packages/
 node_modules/
 releases/files/
+src/.vs/Our.Umbraco.OpeningHours/v16/
+src/.vs/Our.Umbraco.OpeningHours/config/

--- a/src/Our.Umbraco.OpeningHours/App_Plugins/OpeningHours/Controllers/OpeningHoursEditor.js
+++ b/src/Our.Umbraco.OpeningHours/App_Plugins/OpeningHours/Controllers/OpeningHoursEditor.js
@@ -1,5 +1,15 @@
 ﻿angular.module("umbraco").controller("OpeningHours.Controllers.OpeningHoursController", function ($scope) {
 
+    // Double-check that we're getting the model back in the expected format 
+    // (ie.Nested Content might init the property editor with a string)
+    if (typeof ($scope.model.value) === 'string') {
+        if ($scope.model.value === '') {
+            $scope.model.value = {};
+        } else {
+            $scope.model.value = JSON.parse($scope.model.value);
+        }
+    }
+
     function parseBoolean(str) {
         str = str + '';
         return str == '1' || str == 'true';

--- a/src/Our.Umbraco.OpeningHours/App_Plugins/OpeningHours/Directives/Weekdays.js
+++ b/src/Our.Umbraco.OpeningHours/App_Plugins/OpeningHours/Directives/Weekdays.js
@@ -9,8 +9,10 @@
         templateUrl: '/App_Plugins/OpeningHours/Views/Directives/Weekdays.html',
         link: function (scope) {
 
-            function parseBoolean(str) {
-                str = str + '';
+			
+
+			function parseBoolean(str) {
+				str = str + '';
                 return str == '1' || str == 'true';
             }
 
@@ -22,14 +24,20 @@
             scope.weekdays = [];
             scope.times = ['00:00', '00:05', '00:10', '00:15', '00:20', '00:25', '00:30', '00:35', '00:40', '00:45', '00:50', '00:55', '01:00', '01:05', '01:10', '01:15', '01:20', '01:25', '01:30', '01:35', '01:40', '01:45', '01:50', '01:55', '02:00', '02:05', '02:10', '02:15', '02:20', '02:25', '02:30', '02:35', '02:40', '02:45', '02:50', '02:55', '03:00', '03:05', '03:10', '03:15', '03:20', '03:25', '03:30', '03:35', '03:40', '03:45', '03:50', '03:55', '04:00', '04:05', '04:10', '04:15', '04:20', '04:25', '04:30', '04:35', '04:40', '04:45', '04:50', '04:55', '05:00', '05:05', '05:10', '05:15', '05:20', '05:25', '05:30', '05:35', '05:40', '05:45', '05:50', '05:55', '06:00', '06:05', '06:10', '06:15', '06:20', '06:25', '06:30', '06:35', '06:40', '06:45', '06:50', '06:55', '07:00', '07:05', '07:10', '07:15', '07:20', '07:25', '07:30', '07:35', '07:40', '07:45', '07:50', '07:55', '08:00', '08:05', '08:10', '08:15', '08:20', '08:25', '08:30', '08:35', '08:40', '08:45', '08:50', '08:55', '09:00', '09:05', '09:10', '09:15', '09:20', '09:25', '09:30', '09:35', '09:40', '09:45', '09:50', '09:55', '10:00', '10:05', '10:10', '10:15', '10:20', '10:25', '10:30', '10:35', '10:40', '10:45', '10:50', '10:55', '11:00', '11:05', '11:10', '11:15', '11:20', '11:25', '11:30', '11:35', '11:40', '11:45', '11:50', '11:55', '12:00', '12:05', '12:10', '12:15', '12:20', '12:25', '12:30', '12:35', '12:40', '12:45', '12:50', '12:55', '13:00', '13:05', '13:10', '13:15', '13:20', '13:25', '13:30', '13:35', '13:40', '13:45', '13:50', '13:55', '14:00', '14:05', '14:10', '14:15', '14:20', '14:25', '14:30', '14:35', '14:40', '14:45', '14:50', '14:55', '15:00', '15:05', '15:10', '15:15', '15:20', '15:25', '15:30', '15:35', '15:40', '15:45', '15:50', '15:55', '16:00', '16:05', '16:10', '16:15', '16:20', '16:25', '16:30', '16:35', '16:40', '16:45', '16:50', '16:55', '17:00', '17:05', '17:10', '17:15', '17:20', '17:25', '17:30', '17:35', '17:40', '17:45', '17:50', '17:55', '18:00', '18:05', '18:10', '18:15', '18:20', '18:25', '18:30', '18:35', '18:40', '18:45', '18:50', '18:55', '19:00', '19:05', '19:10', '19:15', '19:20', '19:25', '19:30', '19:35', '19:40', '19:45', '19:50', '19:55', '20:00', '20:05', '20:10', '20:15', '20:20', '20:25', '20:30', '20:35', '20:40', '20:45', '20:50', '20:55', '21:00', '21:05', '21:10', '21:15', '21:20', '21:25', '21:30', '21:35', '21:40', '21:45', '21:50', '21:55', '22:00', '22:05', '22:10', '22:15', '22:20', '22:25', '22:30', '22:35', '22:40', '22:45', '22:50', '22:55', '23:00', '23:05', '23:10', '23:15', '23:20', '23:25', '23:30', '23:35', '23:40', '23:45', '23:50', '23:55'];
 
+            // We're watching the "value" comming from the parent scope, since this object is updated on save/publish we need to reinit the view when this happens.
+            // scope.value is also changed when the view loads so this also works as the "init"-call when loading the directive.
+            scope.$watch('value', function() {
+				initModel();
+				initShadowModel();
+			});
+
             // Initializes an empty day
-            function initDay() {
+			function initDay() {
                 return { label: null, items: [] };
             }
 
             // Function for initializing the model (AKA "value" from the directive attribute)
             function initModel() {
-
                 // Convert legacy values (beta1 didn't support multiple times)
                 if (scope.value && typeof (scope.value) == 'object') {
                     angular.forEach(scope.value, function (value, key) {
@@ -56,7 +64,6 @@
 
             // Initializes a shadow array to be used in the UI
             function initShadowModel() {
-                
                 // Some hardcoded days (currently "Monday" is always the first day of the week)
                 var weekdays = [
                     { id: 1, name: 'Monday', alias: 'monday' },
@@ -66,8 +73,11 @@
                     { id: 5, name: "Friday", alias: 'friday' },
                     { id: 6, name: "Saturday", alias: 'saturday' },
                     { id: 0, name: "Sunday", alias: 'sunday' }
-                ];
+				];
 
+                // if need to clear the weekdays-array on the scope so that we don't just append new 
+                // items if initShadowModel is called after a save/publish.
+	            scope.weekdays = [];
                 // Populate the shadow array of weekdays
                 angular.forEach(weekdays, function (day) {
                     scope.value[day.id].label = day.name;
@@ -78,7 +88,7 @@
             }
 
             // Adds a new item to the specified day
-            scope.addItem = function (day) {
+			scope.addItem = function (day) {
                 day.items.push({
                     opens: '09:00',
                     closes: '17:00'
@@ -86,13 +96,9 @@
             };
 
             // Removes an item for day at the specified index
-            scope.removeItem = function (day, index) {
+			scope.removeItem = function (day, index) {
                 day.items.splice(index, 1);
             };
-
-            initModel();
-            initShadowModel();
-
         }
     };
 });

--- a/src/Our.Umbraco.OpeningHours/Composition/OpeningHoursComposer.cs
+++ b/src/Our.Umbraco.OpeningHours/Composition/OpeningHoursComposer.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Our.Umbraco.OpeningHours.Converters;
+using Umbraco.Core;
+using Umbraco.Core.Composing;
+
+namespace Our.Umbraco.OpeningHours.Composition
+{
+    public class OpeningHoursComposer : IUserComposer
+    {
+        public void Compose(global::Umbraco.Core.Composing.Composition composition)
+        {
+            // Appending property value converter
+            composition.PropertyValueConverters().Append<OpeningHoursValueConverter>();
+        }
+    }
+}

--- a/src/Our.Umbraco.OpeningHours/Converters/OpeningHoursValueConverter.cs
+++ b/src/Our.Umbraco.OpeningHours/Converters/OpeningHoursValueConverter.cs
@@ -7,28 +7,53 @@ using Our.Umbraco.OpeningHours.Model;
 
 namespace Our.Umbraco.OpeningHours.Converters
 {
-    [PropertyValueType(typeof(OpeningHoursModel))]
-    [PropertyValueCache(PropertyCacheValue.All, PropertyCacheLevel.Content)]
-    public class OpeningHoursValueConverter : PropertyValueConverterBase
+    public class OpeningHoursValueConverter : IPropertyValueConverter
     {
-        public override bool IsConverter(PublishedPropertyType propertyType)
+        private readonly ILogger _logger;
+
+        public OpeningHoursValueConverter(ILogger logger)
         {
-            return propertyType.PropertyEditorAlias.InvariantEquals("OpeningHours");
+            _logger = logger;
         }
 
-        public override object ConvertDataToSource(PublishedPropertyType propertyType, object source, bool preview)
+        public bool IsConverter(PublishedPropertyType propertyType)
+        {
+            return propertyType.EditorAlias.Equals("OpeningHours");
+        } 
+
+        public bool? IsValue(object value, PropertyValueLevel level)
+        {
+            return true;
+        }
+
+        public Type GetPropertyValueType(PublishedPropertyType propertyType) => typeof(OpeningHoursModel);
+
+        public object ConvertSourceToIntermediate(IPublishedElement owner, PublishedPropertyType propertyType, object source, bool preview)
+        {
+            return source;
+        }
+
+        public object ConvertIntermediateToObject(IPublishedElement owner, PublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
         {
             try
             {
-                return Model.OpeningHoursModel.Deserialize(source as string);
+                return OpeningHoursModel.Deserialize(inter as string);
             }
             catch (Exception e)
             {
-                LogHelper.Error<OpeningHoursValueConverter>("Error converting value", e);
+                _logger.Error<OpeningHoursValueConverter>("Error converting value", e);
             }
 
             // Create default model
-            return new Model.OpeningHoursModel();
+            return new OpeningHoursModel();
         }
+
+        public object ConvertIntermediateToXPath(IPublishedElement owner, PublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+        {
+            return inter.ToString();
+        }
+
+        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+
     }
 }

--- a/src/Our.Umbraco.OpeningHours/Converters/OpeningHoursValueConverter.cs
+++ b/src/Our.Umbraco.OpeningHours/Converters/OpeningHoursValueConverter.cs
@@ -9,89 +9,46 @@ namespace Our.Umbraco.OpeningHours.Converters
 {
     public class OpeningHoursValueConverter : IPropertyValueConverter
     {
+        private readonly ILogger _logger;
+
+        public OpeningHoursValueConverter(ILogger logger)
+        {
+            _logger = logger;
+        }
 
         public bool IsConverter(IPublishedPropertyType propertyType) => propertyType.EditorAlias.Equals("OpeningHours");
+        public Type GetPropertyValueType(IPublishedPropertyType propertyType) => typeof(OpeningHoursModel);
+        public PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;
         
-
         public bool? IsValue(object value, PropertyValueLevel level)
         {
-            throw new NotImplementedException();
+            return true;
         }
 
-        public Type GetPropertyValueType(IPublishedPropertyType propertyType)
+        public object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source, bool preview)
         {
-            throw new NotImplementedException();
+            return source;
         }
 
-        public PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
+        public object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
         {
-            throw new NotImplementedException();
+            try
+            {
+                return OpeningHoursModel.Deserialize(inter as string);
+            }
+            catch (Exception e)
+            {
+                _logger.Error<OpeningHoursValueConverter>("Error converting value", e);
+            }
+
+            // Create default model
+            return new OpeningHoursModel();
         }
 
-        public object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source,
-            bool preview)
+        public object ConvertIntermediateToXPath(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
         {
-            throw new NotImplementedException();
+            return inter.ToString();
         }
-
-        public object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType,
-            PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
-        {
-            throw new NotImplementedException();
-        }
-
-        public object ConvertIntermediateToXPath(IPublishedElement owner, IPublishedPropertyType propertyType,
-            PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
-        {
-            throw new NotImplementedException();
-        }
-
-
-        //private readonly ILogger _logger;
-
-        //public OpeningHoursValueConverter(ILogger logger)
-        //{
-        //    _logger = logger;
-        //}
-
-        //public bool IsConverter(PublishedPropertyType propertyType)
-        //{
-        //    
-        //} 
-
-        //public bool? IsValue(object value, PropertyValueLevel level)
-        //{
-        //    return true;
-        //}
-
-        //public Type GetPropertyValueType(PublishedPropertyType propertyType) => typeof(OpeningHoursModel);
-
-        //public object ConvertSourceToIntermediate(IPublishedElement owner, PublishedPropertyType propertyType, object source, bool preview)
-        //{
-        //    return source;
-        //}
-
-        //public object ConvertIntermediateToObject(IPublishedElement owner, PublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
-        //{
-        //    try
-        //    {
-        //        return OpeningHoursModel.Deserialize(inter as string);
-        //    }
-        //    catch (Exception e)
-        //    {
-        //        _logger.Error<OpeningHoursValueConverter>("Error converting value", e);
-        //    }
-
-        //    // Create default model
-        //    return new OpeningHoursModel();
-        //}
-
-        //public object ConvertIntermediateToXPath(IPublishedElement owner, PublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
-        //{
-        //    return inter.ToString();
-        //}
-
-        //public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType) => PropertyCacheLevel.Element;
 
     }
 }

--- a/src/Our.Umbraco.OpeningHours/Converters/OpeningHoursValueConverter.cs
+++ b/src/Our.Umbraco.OpeningHours/Converters/OpeningHoursValueConverter.cs
@@ -9,51 +9,89 @@ namespace Our.Umbraco.OpeningHours.Converters
 {
     public class OpeningHoursValueConverter : IPropertyValueConverter
     {
-        private readonly ILogger _logger;
 
-        public OpeningHoursValueConverter(ILogger logger)
-        {
-            _logger = logger;
-        }
-
-        public bool IsConverter(PublishedPropertyType propertyType)
-        {
-            return propertyType.EditorAlias.Equals("OpeningHours");
-        } 
+        public bool IsConverter(IPublishedPropertyType propertyType) => propertyType.EditorAlias.Equals("OpeningHours");
+        
 
         public bool? IsValue(object value, PropertyValueLevel level)
         {
-            return true;
+            throw new NotImplementedException();
         }
 
-        public Type GetPropertyValueType(PublishedPropertyType propertyType) => typeof(OpeningHoursModel);
-
-        public object ConvertSourceToIntermediate(IPublishedElement owner, PublishedPropertyType propertyType, object source, bool preview)
+        public Type GetPropertyValueType(IPublishedPropertyType propertyType)
         {
-            return source;
+            throw new NotImplementedException();
         }
 
-        public object ConvertIntermediateToObject(IPublishedElement owner, PublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+        public PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
         {
-            try
-            {
-                return OpeningHoursModel.Deserialize(inter as string);
-            }
-            catch (Exception e)
-            {
-                _logger.Error<OpeningHoursValueConverter>("Error converting value", e);
-            }
-
-            // Create default model
-            return new OpeningHoursModel();
+            throw new NotImplementedException();
         }
 
-        public object ConvertIntermediateToXPath(IPublishedElement owner, PublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+        public object ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object source,
+            bool preview)
         {
-            return inter.ToString();
+            throw new NotImplementedException();
         }
 
-        public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+        public object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType,
+            PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object ConvertIntermediateToXPath(IPublishedElement owner, IPublishedPropertyType propertyType,
+            PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        //private readonly ILogger _logger;
+
+        //public OpeningHoursValueConverter(ILogger logger)
+        //{
+        //    _logger = logger;
+        //}
+
+        //public bool IsConverter(PublishedPropertyType propertyType)
+        //{
+        //    
+        //} 
+
+        //public bool? IsValue(object value, PropertyValueLevel level)
+        //{
+        //    return true;
+        //}
+
+        //public Type GetPropertyValueType(PublishedPropertyType propertyType) => typeof(OpeningHoursModel);
+
+        //public object ConvertSourceToIntermediate(IPublishedElement owner, PublishedPropertyType propertyType, object source, bool preview)
+        //{
+        //    return source;
+        //}
+
+        //public object ConvertIntermediateToObject(IPublishedElement owner, PublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+        //{
+        //    try
+        //    {
+        //        return OpeningHoursModel.Deserialize(inter as string);
+        //    }
+        //    catch (Exception e)
+        //    {
+        //        _logger.Error<OpeningHoursValueConverter>("Error converting value", e);
+        //    }
+
+        //    // Create default model
+        //    return new OpeningHoursModel();
+        //}
+
+        //public object ConvertIntermediateToXPath(IPublishedElement owner, PublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+        //{
+        //    return inter.ToString();
+        //}
+
+        //public PropertyCacheLevel GetPropertyCacheLevel(PublishedPropertyType propertyType) => PropertyCacheLevel.Element;
 
     }
 }

--- a/src/Our.Umbraco.OpeningHours/Extensions/JArrayExtensions.cs
+++ b/src/Our.Umbraco.OpeningHours/Extensions/JArrayExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Newtonsoft.Json.Linq;
+
+namespace Our.Umbraco.OpeningHours.Extensions
+{
+    public static class JArrayExtensions
+    {
+    
+        /// <summary>
+        /// Gets an array of <typeparamref name="T"/> from the token matching the specified <paramref name="path"/>,
+        /// using the specified delegate <paramref name="callback"/> for parsing each item in the array.
+        /// </summary>
+        /// <param name="obj">The instance of <see cref="JObject"/>.</param>
+        /// <param name="path">A <see cref="string"/> that contains a JPath expression.</param>
+        /// <param name="callback">A callback function used for parsing or converting the token value.</param>
+        public static T[] GetArray<T>(this JObject obj, string path, Func<JObject, T> callback)
+        {
+
+            if (!(obj?.SelectToken(path) is JArray token)) return null;
+
+            return (
+                from child in token
+                where child is JObject
+                select callback((JObject)child)
+            ).ToArray();
+
+        }
+    }
+}

--- a/src/Our.Umbraco.OpeningHours/Extensions/JTokenExtensions.cs
+++ b/src/Our.Umbraco.OpeningHours/Extensions/JTokenExtensions.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Newtonsoft.Json.Linq;
+
+namespace Our.Umbraco.OpeningHours.Extensions
+{
+
+    public static class JObjectExtensions
+    {
+        /// <summary>
+        /// Gets an object from a token matching the specified <paramref name="path"/>.
+        /// </summary>
+        /// <param name="obj">The parent object.</param>
+        /// <param name="path">A <see cref="string"/> that contains a JPath expression.</param>
+        /// <param name="func">The delegate (callback method) used for parsing the object.</param>
+        /// <returns>An instance of <typeparamref name="T"/>, or the default value of <typeparamref name="T"/> if not
+        /// found.</returns>
+        public static T GetObject<T>(this JObject obj, string path, Func<JObject, T> func)
+        {
+            return obj == null ? default(T) : func(obj.SelectToken(path) as JObject);
+        }
+
+        /// <summary>
+        /// Gets the string value of the token matching the specified <paramref name="path"/>, or <c>null</c> if
+        /// <paramref name="path"/> doesn't match a token.
+        /// </summary>
+        /// <param name="obj">The parent object.</param>
+        /// <param name="path">A <see cref="string"/> that contains a JPath expression.</param>
+        /// <returns>An instance of <see cref="string"/>, or <c>null</c>.</returns>
+        public static string GetString(this JObject obj, string path)
+        {
+            if (obj == null) return null;
+            JToken token = GetSimpleTypeTokenFromPath(obj, path);
+            return token?.Value<string>();
+        }
+
+        /// <summary>
+        /// Gets the value of the token matching the specified <paramref name="path"/>, or <c>null</c> if
+        /// <paramref name="path"/> doesn't match a token.
+        /// </summary>
+        /// <param name="obj">The parent object.</param>
+        /// <param name="path">A <see cref="string"/> that contains a JPath expression.</param>
+        /// <param name="callback">The callback used for converting the string value.</param>
+        /// <returns>An instance of <typeparamref name="T"/>, or <c>null</c>.</returns>
+        public static T GetString<T>(this JObject obj, string path, Func<string, T> callback)
+        {
+            if (obj == null) return default(T);
+            JToken token = GetSimpleTypeTokenFromPath(obj, path);
+            return token == null ? default(T) : callback(token.Value<string>());
+        }
+
+        /// <summary>
+        /// Gets the <see cref="bool"/> value of the token matching the specified <paramref name="path"/>, or
+        /// <c>0</c> if <paramref name="path"/> doesn't match a token.
+        /// </summary>
+        /// <param name="obj">The parent object.</param>
+        /// <param name="path">A <see cref="string"/> that contains a JPath expression.</param>
+        /// <returns>An instance of <see cref="bool"/>.</returns>
+        public static bool GetBoolean(this JObject obj, string path)
+        {
+            return GetBoolean(obj, path, x => x);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="bool"/> value of the token matching the specified <paramref name="path"/> and parses
+        /// it into an instance of <typeparamref name="T"/>, or the default value of <typeparamref name="T"/> if
+        /// <paramref name="path"/> doesn't match a token.
+        /// </summary>
+        /// <param name="obj">The parent object.</param>
+        /// <param name="path">A <see cref="string"/> that contains a JPath expression.</param>
+        /// <param name="callback">A callback function used for parsing or converting the token value.</param>
+        /// <returns>An instance of <see cref="bool"/>, or <c>false</c> if <paramref name="path"/>
+        /// doesn't match a token.</returns>
+        public static T GetBoolean<T>(this JObject obj, string path, Func<bool, T> callback)
+        {
+
+            // Get the token from the path
+            JToken token = GetSimpleTypeTokenFromPath(obj, path);
+
+            // Check whether the token is null
+            if (token == null || token.Type == JTokenType.Null) return default(T);
+
+            // Convert the value to a boolean
+            bool value = token.ToString().Equals("true",StringComparison.InvariantCultureIgnoreCase);
+
+            // Invoke the callback and return the value
+            return callback(value);
+
+        }
+
+        /// <summary>
+        /// Gets the <see cref="JToken"/> at the specified <paramref name="path"/>. If the type of the token is either
+        /// <see cref="JTokenType.Object"/> or <see cref="JTokenType.Array"/>, the method will return
+        /// <c>null</c> instead.
+        /// </summary>
+        /// <param name="obj">The instance of <see cref="JObject"/>.</param>
+        /// <param name="path">A <see cref="string"/> that contains a JPath expression.</param>
+        /// <returns>An instance of <see cref="JToken"/>, or <c>null</c>.</returns>
+        private static JToken GetSimpleTypeTokenFromPath(JObject obj, string path)
+        {
+            JToken token = obj?.SelectToken(path);
+            return token == null || token.Type == JTokenType.Object || token.Type == JTokenType.Array ? null : token;
+        }
+
+        /// <summary>
+        /// Gets the items of the <see cref="JArray"/> from the token matching the specfied <paramref name="path"/>.
+        /// </summary>
+        /// <param name="obj">The instance of <see cref="JObject"/>.</param>
+        /// <param name="path">A <see cref="string"/> that contains a JPath expression.</param>
+        /// <param name="callback">A callback function used for parsing or converting the token value.</param>
+        /// <returns>An array of <typeparamref name="T"/>. If the a matching token isn't found, an empty array will
+        /// still be returned.</returns>
+        public static T[] GetArrayItems<T>(this JObject obj, string path, Func<JObject, T> callback)
+        {
+
+            if (!(obj?.SelectToken(path) is JArray token)) return new T[0];
+
+            return (
+                from JObject child in token
+                select callback(child)
+            ).ToArray();
+
+        }
+
+
+    }
+
+}

--- a/src/Our.Umbraco.OpeningHours/Extensions/OpeningHoursExtensions.cs
+++ b/src/Our.Umbraco.OpeningHours/Extensions/OpeningHoursExtensions.cs
@@ -4,6 +4,7 @@ using Our.Umbraco.OpeningHours.Model;
 using Our.Umbraco.OpeningHours.Model.Items;
 using Our.Umbraco.OpeningHours.Model.Offset;
 using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Web;
 
 namespace Our.Umbraco.OpeningHours.Extensions {
@@ -30,7 +31,7 @@ namespace Our.Umbraco.OpeningHours.Extensions {
         /// <param name="propertyAlias">The alias of the property.</param>
         /// <returns>Returns an instance of <see cref="OpeningHoursModel"/>.</returns>
         public static OpeningHoursModel GetOpeningHours(this IPublishedContent content, string propertyAlias) {
-            OpeningHoursModel openingHours = content == null ? null : content.GetPropertyValue<OpeningHoursModel>(propertyAlias);
+            OpeningHoursModel openingHours = content == null ? null : content.Value<OpeningHoursModel>(propertyAlias);
             return openingHours ?? new OpeningHoursModel();
         }
 

--- a/src/Our.Umbraco.OpeningHours/Json/JsonObjectBase.cs
+++ b/src/Our.Umbraco.OpeningHours/Json/JsonObjectBase.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Our.Umbraco.OpeningHours.Json
+{
+    /// <summary>
+    /// Class representing an object that was parsed from an instance of <see cref="Newtonsoft.Json.Linq.JObject"/>.
+    /// </summary>
+    public class JsonObjectBase
+    {
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the internal <see cref="Newtonsoft.Json.Linq.JObject"/> the object was created from.
+        /// </summary>
+        [JsonIgnore]
+        public JObject JObject { get; }
+
+        #endregion
+
+        #region Constructor
+
+        /// <summary>
+        /// Initializes a new instance from the specified <paramref name="obj"/>.
+        /// </summary>
+        /// <param name="obj">The instance of <see cref="Newtonsoft.Json.Linq.JObject"/> representing the object.</param>
+        protected JsonObjectBase(JObject obj)
+        {
+            JObject = obj;
+        }
+
+        #endregion
+
+    }
+}

--- a/src/Our.Umbraco.OpeningHours/Model/Items/OpeningHoursHolidayItem.cs
+++ b/src/Our.Umbraco.OpeningHours/Model/Items/OpeningHoursHolidayItem.cs
@@ -2,7 +2,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Our.Umbraco.OpeningHours.Json;
-using Skybrud.Essentials.Json.Extensions;
 
 namespace Our.Umbraco.OpeningHours.Model.Items {
     
@@ -38,8 +37,11 @@ namespace Our.Umbraco.OpeningHours.Model.Items {
 
         #region Constructors
 
-        protected OpeningHoursHolidayItem(JObject obj) : base(obj, default(DayOfWeek)) {
-            Date = obj.GetString("date", ParseDate);
+        protected OpeningHoursHolidayItem(JObject obj) : base(obj, default(DayOfWeek))
+        {
+            
+            Date = ParseDate(obj["date"]);
+            //Date = obj.GetString("date", ParseDate);
             DayOfWeek = Date.DayOfWeek;
         }
 
@@ -47,9 +49,13 @@ namespace Our.Umbraco.OpeningHours.Model.Items {
 
         #region Static methods
 
-        private DateTime ParseDate(string str) {
+        private DateTime ParseDate(JToken objDate)
+        {
+            if (objDate == null)
+                return default(DateTime);
+
             DateTime date;
-            return DateTime.TryParse(str ?? "", out date) ? date : default(DateTime);
+            return DateTime.TryParse(objDate.Value<string>() ?? "", out date) ? date : default(DateTime);
         }
 
         /// <summary>

--- a/src/Our.Umbraco.OpeningHours/Model/Items/OpeningHoursTimeSlot.cs
+++ b/src/Our.Umbraco.OpeningHours/Model/Items/OpeningHoursTimeSlot.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Our.Umbraco.OpeningHours.Extensions;
 using Our.Umbraco.OpeningHours.Json;
 using Our.Umbraco.OpeningHours.Model.Json;
-using Skybrud.Essentials.Json.Extensions;
 
 namespace Our.Umbraco.OpeningHours.Model.Items {
 

--- a/src/Our.Umbraco.OpeningHours/Model/Items/OpeningHoursWeekdayItem.cs
+++ b/src/Our.Umbraco.OpeningHours/Model/Items/OpeningHoursWeekdayItem.cs
@@ -2,9 +2,12 @@
 using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+//using Newtonsoft.Json.Linq;
+//using Newtonsoft.Json;
+//using Newtonsoft.Json.Linq;
+using Our.Umbraco.OpeningHours.Extensions;
 using Our.Umbraco.OpeningHours.Model.Json;
-using Skybrud.Essentials.Json.Extensions;
-using Skybrud.Essentials.Strings.Extensions;
+using Umbraco.Core;
 
 namespace Our.Umbraco.OpeningHours.Model.Items {
     
@@ -64,7 +67,7 @@ namespace Our.Umbraco.OpeningHours.Model.Items {
         /// </summary>
         [JsonIgnore]
         public virtual string WeekDayNameFirstCharToUpper {
-            get { return WeekDayName.FirstCharToUpper(); }
+            get { return WeekDayName.ToFirstUpper(); }
         }
 
         #endregion

--- a/src/Our.Umbraco.OpeningHours/Model/Json/OpeningHoursJsonObject.cs
+++ b/src/Our.Umbraco.OpeningHours/Model/Json/OpeningHoursJsonObject.cs
@@ -1,5 +1,5 @@
 ﻿using Newtonsoft.Json.Linq;
-using Skybrud.Essentials.Json;
+using Our.Umbraco.OpeningHours.Json;
 
 namespace Our.Umbraco.OpeningHours.Model.Json {
     

--- a/src/Our.Umbraco.OpeningHours/Model/OpeningHoursDay.cs
+++ b/src/Our.Umbraco.OpeningHours/Model/OpeningHoursDay.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using System.Linq;
 using Our.Umbraco.OpeningHours.Extensions;
 using Our.Umbraco.OpeningHours.Model.Items;
-using Skybrud.Essentials.Strings.Extensions;
+using Umbraco.Core;
 
 namespace Our.Umbraco.OpeningHours.Model {
 
@@ -88,7 +88,7 @@ namespace Our.Umbraco.OpeningHours.Model {
         /// the name will always be uppercase.
         /// </summary>
         public string WeekDayNameFirstCharToUpper {
-            get { return WeekDayName.FirstCharToUpper(); }
+            get { return WeekDayName.ToFirstUpper(); }
         }
 
         /// <summary>

--- a/src/Our.Umbraco.OpeningHours/Model/OpeningHoursModel.cs
+++ b/src/Our.Umbraco.OpeningHours/Model/OpeningHoursModel.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Our.Umbraco.OpeningHours.Extensions;
 using Our.Umbraco.OpeningHours.Json;
 using Our.Umbraco.OpeningHours.Model.Items;
 using Our.Umbraco.OpeningHours.Model.Json;
 using Our.Umbraco.OpeningHours.Model.Offset;
-using Skybrud.Essentials.Json.Extensions;
 using Umbraco.Core;
 
 namespace Our.Umbraco.OpeningHours.Model {

--- a/src/Our.Umbraco.OpeningHours/Our.Umbraco.OpeningHours.csproj
+++ b/src/Our.Umbraco.OpeningHours/Our.Umbraco.OpeningHours.csproj
@@ -46,17 +46,17 @@
     <Reference Include="AutoMapper, Version=8.0.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
       <HintPath>..\packages\AutoMapper.8.0.0\lib\net461\AutoMapper.dll</HintPath>
     </Reference>
-    <Reference Include="ClientDependency.Core, Version=1.9.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ClientDependency.1.9.7\lib\net45\ClientDependency.Core.dll</HintPath>
+    <Reference Include="ClientDependency.Core, Version=1.9.8.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClientDependency.1.9.8\lib\net45\ClientDependency.Core.dll</HintPath>
     </Reference>
-    <Reference Include="ClientDependency.Core.Mvc, Version=1.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ClientDependency-Mvc5.1.8.0.0\lib\net45\ClientDependency.Core.Mvc.dll</HintPath>
+    <Reference Include="ClientDependency.Core.Mvc, Version=1.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClientDependency-Mvc5.1.9.3\lib\net45\ClientDependency.Core.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="CSharpTest.Net.Collections, Version=14.906.1403.1082, Culture=neutral, PublicKeyToken=06aee00cce822474, processorArchitecture=MSIL">
       <HintPath>..\packages\CSharpTest.Net.Collections.14.906.1403.1082\lib\net40\CSharpTest.Net.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="Examine, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Examine.1.0.0\lib\net452\Examine.dll</HintPath>
+    <Reference Include="Examine, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Examine.1.0.1\lib\net452\Examine.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.8.14.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlAgilityPack.1.8.14\lib\Net45\HtmlAgilityPack.dll</HintPath>
@@ -158,8 +158,14 @@
     <Reference Include="Serilog.Settings.AppSettings, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Settings.AppSettings.2.2.2\lib\net45\Serilog.Settings.AppSettings.dll</HintPath>
     </Reference>
+    <Reference Include="Serilog.Sinks.Async, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Async.1.3.0\lib\net45\Serilog.Sinks.Async.dll</HintPath>
+    </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Map, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Map.1.0.0\lib\netstandard2.0\Serilog.Sinks.Map.dll</HintPath>
     </Reference>
     <Reference Include="Superpower, Version=1.0.0.0, Culture=neutral, PublicKeyToken=aec39280ded1b3a7, processorArchitecture=MSIL">
       <HintPath>..\packages\Superpower.2.0.0\lib\net45\Superpower.dll</HintPath>
@@ -232,16 +238,16 @@
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Umbraco.Core, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Core.8.0.0\lib\net472\Umbraco.Core.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Core.8.4.0\lib\net472\Umbraco.Core.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Examine, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.0.0\lib\net472\Umbraco.Examine.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Web.8.4.0\lib\net472\Umbraco.Examine.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Web, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.0.0\lib\net472\Umbraco.Web.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Web.8.4.0\lib\net472\Umbraco.Web.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Web.UI, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.0.0\lib\net472\Umbraco.Web.UI.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Web.8.4.0\lib\net472\Umbraco.Web.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -296,6 +302,13 @@
     <Content Include="Our.Umbraco.OpeningHours.nuspec" />
     <Content Include="App_Plugins\OpeningHours\css\openingHours.less" />
     <None Include="Properties\AssemblyInfo.json" />
+    <Content Include="web.config" />
+    <None Include="web.Debug.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
+    <None Include="web.Release.config">
+      <DependentUpon>web.config</DependentUpon>
+    </None>
   </ItemGroup>
   <ItemGroup />
   <PropertyGroup>

--- a/src/Our.Umbraco.OpeningHours/Our.Umbraco.OpeningHours.csproj
+++ b/src/Our.Umbraco.OpeningHours/Our.Umbraco.OpeningHours.csproj
@@ -22,6 +22,8 @@
     <UseGlobalApplicationHostFile />
     <TargetFrameworkProfile />
     <Use64BitIISExpress />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,18 +43,155 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AutoMapper, Version=8.0.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.8.0.0\lib\net461\AutoMapper.dll</HintPath>
+    </Reference>
+    <Reference Include="ClientDependency.Core, Version=1.9.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClientDependency.1.9.7\lib\net45\ClientDependency.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="ClientDependency.Core.Mvc, Version=1.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClientDependency-Mvc5.1.8.0.0\lib\net45\ClientDependency.Core.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="CSharpTest.Net.Collections, Version=14.906.1403.1082, Culture=neutral, PublicKeyToken=06aee00cce822474, processorArchitecture=MSIL">
+      <HintPath>..\packages\CSharpTest.Net.Collections.14.906.1403.1082\lib\net40\CSharpTest.Net.Collections.dll</HintPath>
+    </Reference>
+    <Reference Include="Examine, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Examine.1.0.0\lib\net452\Examine.dll</HintPath>
+    </Reference>
+    <Reference Include="HtmlAgilityPack, Version=1.8.14.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\packages\HtmlAgilityPack.1.8.14\lib\Net45\HtmlAgilityPack.dll</HintPath>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    </Reference>
+    <Reference Include="ImageProcessor, Version=2.7.0.100, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ImageProcessor.2.7.0.100\lib\net452\ImageProcessor.dll</HintPath>
+    </Reference>
+    <Reference Include="LightInject, Version=5.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\LightInject.5.4.0\lib\net46\LightInject.dll</HintPath>
+    </Reference>
+    <Reference Include="LightInject.Annotation, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\LightInject.Annotation.1.1.0\lib\net46\LightInject.Annotation.dll</HintPath>
+    </Reference>
+    <Reference Include="LightInject.Mvc, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\LightInject.Mvc.2.0.0\lib\net46\LightInject.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="LightInject.Web, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\LightInject.Web.2.0.0\lib\net46\LightInject.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="LightInject.WebApi, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\LightInject.WebApi.2.0.0\lib\net46\LightInject.WebApi.dll</HintPath>
+    </Reference>
+    <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
+      <HintPath>..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
+    </Reference>
+    <Reference Include="Markdown, Version=2.0.0.0, Culture=neutral, PublicKeyToken=1b320cc08ad5aa89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Markdown.2.2.1\lib\net451\Markdown.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.2\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.Owin, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Identity.Owin.2.2.2\lib\net45\Microsoft.AspNet.Identity.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.SignalR.Core.2.4.0\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.4.0.1\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.4.0.1\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.Cookies, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.Cookies.4.0.1\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.OAuth, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.OAuth.4.0.1\lib\net45\Microsoft.Owin.Security.OAuth.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="MiniProfiler, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b44f9351044011a3, processorArchitecture=MSIL">
+      <HintPath>..\packages\MiniProfiler.4.0.138\lib\net461\MiniProfiler.dll</HintPath>
+    </Reference>
+    <Reference Include="MiniProfiler.Shared, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b44f9351044011a3, processorArchitecture=MSIL">
+      <HintPath>..\packages\MiniProfiler.Shared.4.0.138\lib\net461\MiniProfiler.Shared.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="NPoco, Version=3.9.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\NPoco.3.9.4\lib\net45\NPoco.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Semver, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Semver.2.0.4\lib\net452\Semver.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.8.0\lib\net46\Serilog.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Enrichers.Process, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Enrichers.Process.2.0.1\lib\net45\Serilog.Enrichers.Process.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Enrichers.Thread, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Enrichers.Thread.3.0.0\lib\net45\Serilog.Enrichers.Thread.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Filters.Expressions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Filters.Expressions.2.0.0\lib\net45\Serilog.Filters.Expressions.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Formatting.Compact, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Compact.1.0.0\lib\net45\Serilog.Formatting.Compact.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Formatting.Compact.Reader, Version=1.0.3.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Formatting.Compact.Reader.1.0.3\lib\net45\Serilog.Formatting.Compact.Reader.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Settings.AppSettings, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Settings.AppSettings.2.2.2\lib\net45\Serilog.Settings.AppSettings.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Superpower, Version=1.0.0.0, Culture=neutral, PublicKeyToken=aec39280ded1b3a7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Superpower.2.0.0\lib\net45\Superpower.dll</HintPath>
+    </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\System.Data.SqlServerCe.dll</HintPath>
+    <Reference Include="System.Data.Linq" />
+    <Reference Include="System.Data.SqlServerCe, Version=4.0.0.1, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <HintPath>..\packages\Umbraco.SqlServerCE.4.0.0.1\lib\net472\System.Data.SqlServerCe.dll</HintPath>
     </Reference>
-    <Reference Include="System.Data.SqlServerCe.Entity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\System.Data.SqlServerCe.Entity.dll</HintPath>
+    <Reference Include="System.Data.SqlServerCe.Entity, Version=4.0.0.1, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <HintPath>..\packages\Umbraco.SqlServerCE.4.0.0.1\lib\net472\System.Data.SqlServerCe.Entity.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.4.0.30506.0\lib\net40\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO" />
+    <Reference Include="System.Linq.Expressions" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security" />
+    <Reference Include="System.Threading.Tasks" />
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Dataflow.4.9.0\lib\netstandard2.0\System.Threading.Tasks.Dataflow.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
@@ -61,30 +200,58 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.4.0.30506.0\lib\net40\System.Web.Http.dll</HintPath>
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.WebHost, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.4.0.30506.0\lib\net40\System.Web.Http.WebHost.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.Mvc.4.0.30506.0\lib\net40\System.Web.Mvc.dll</HintPath>
+    <Reference Include="System.Web.Http, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.7\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.7\lib\net45\System.Web.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.7\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="Umbraco.Core, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.8.0.0\lib\net472\Umbraco.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Umbraco.Examine, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Web.8.0.0\lib\net472\Umbraco.Examine.dll</HintPath>
+    </Reference>
+    <Reference Include="Umbraco.Web, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Web.8.0.0\lib\net472\Umbraco.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="Umbraco.Web.UI, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Web.8.0.0\lib\net472\Umbraco.Web.UI.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Composition\OpeningHoursComposer.cs" />
     <Compile Include="Converters\OpeningHoursValueConverter.cs" />
+    <Compile Include="Extensions\JArrayExtensions.cs" />
+    <Compile Include="Extensions\JTokenExtensions.cs" />
     <Compile Include="Extensions\OpeningHoursExtensions.cs" />
     <Compile Include="Extensions\DateTimeExtensions.cs" />
+    <Compile Include="Json\JsonObjectBase.cs" />
     <Compile Include="Json\OpeningHoursJsonConverter.cs" />
     <Compile Include="Model\Items\OpeningHoursDayTimeSlot.cs" />
     <Compile Include="Model\Items\OpeningHoursTimeSlot.cs" />
@@ -130,6 +297,7 @@
     <Content Include="App_Plugins\OpeningHours\css\openingHours.less" />
     <None Include="Properties\AssemblyInfo.json" />
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -158,6 +326,13 @@
   <PropertyGroup>
     <PostBuildEvent>"$(SolutionDir)..\build\UpdateAssemblyInfoJson.exe" "$(ProjectPath)" "$(TargetPath)"</PostBuildEvent>
   </PropertyGroup>
+  <Import Project="..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets" Condition="Exists('..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Our.Umbraco.OpeningHours/Our.Umbraco.OpeningHours.csproj
+++ b/src/Our.Umbraco.OpeningHours/Our.Umbraco.OpeningHours.csproj
@@ -13,13 +13,15 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Our.Umbraco.OpeningHours</RootNamespace>
     <AssemblyName>Our.Umbraco.OpeningHours</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
+    <TargetFrameworkProfile />
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,89 +41,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper">
-      <HintPath>..\packages\AutoMapper.3.0.0\lib\net40\AutoMapper.dll</HintPath>
-    </Reference>
-    <Reference Include="AutoMapper.Net4">
-      <HintPath>..\packages\AutoMapper.3.0.0\lib\net40\AutoMapper.Net4.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="businesslogic">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\businesslogic.dll</HintPath>
-    </Reference>
-    <Reference Include="ClientDependency.Core">
-      <HintPath>..\packages\ClientDependency.1.8.2.1\lib\net45\ClientDependency.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="ClientDependency.Core.Mvc">
-      <HintPath>..\packages\ClientDependency-Mvc.1.8.0.0\lib\net45\ClientDependency.Core.Mvc.dll</HintPath>
-    </Reference>
-    <Reference Include="cms">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\cms.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="controls">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\controls.dll</HintPath>
-    </Reference>
-    <Reference Include="CookComputing.XmlRpcV2">
-      <HintPath>..\packages\xmlrpcnet.2.5.0\lib\net20\CookComputing.XmlRpcV2.dll</HintPath>
-    </Reference>
-    <Reference Include="Examine">
-      <HintPath>..\packages\Examine.0.1.57.2941\lib\Examine.dll</HintPath>
-    </Reference>
-    <Reference Include="HtmlAgilityPack">
-      <HintPath>..\packages\HtmlAgilityPack.1.4.6\lib\Net45\HtmlAgilityPack.dll</HintPath>
-    </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib">
-      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
-    </Reference>
-    <Reference Include="ImageProcessor">
-      <HintPath>..\packages\ImageProcessor.1.9.5.0\lib\ImageProcessor.dll</HintPath>
-    </Reference>
-    <Reference Include="ImageProcessor.Web">
-      <HintPath>..\packages\ImageProcessor.Web.3.3.1.0\lib\net45\ImageProcessor.Web.dll</HintPath>
-    </Reference>
-    <Reference Include="interfaces">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\interfaces.dll</HintPath>
-    </Reference>
-    <Reference Include="log4net">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\log4net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Lucene.Net">
-      <HintPath>..\packages\Lucene.Net.2.9.4.1\lib\net40\Lucene.Net.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationBlocks.Data">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\Microsoft.ApplicationBlocks.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Web.Helpers">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\Microsoft.Web.Helpers.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Web.Mvc.FixedDisplayModes">
-      <HintPath>..\packages\Microsoft.AspNet.Mvc.FixedDisplayModes.1.0.1\lib\net40\Microsoft.Web.Mvc.FixedDisplayModes.dll</HintPath>
-    </Reference>
-    <Reference Include="MiniProfiler">
-      <HintPath>..\packages\MiniProfiler.2.1.0\lib\net40\MiniProfiler.dll</HintPath>
-    </Reference>
-    <Reference Include="MySql.Data">
-      <HintPath>..\packages\MySql.Data.6.6.5\lib\net40\MySql.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Skybrud.Essentials, Version=1.0.8.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Skybrud.Essentials.1.0.8\lib\net45\Skybrud.Essentials.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="SQLCE4Umbraco">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\SQLCE4Umbraco.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\System.Data.SqlServerCe.dll</HintPath>
@@ -140,13 +60,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.Helpers.dll</HintPath>
-    </Reference>
     <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.4.0.30506.0\lib\net40\System.Web.Http.dll</HintPath>
@@ -159,64 +73,13 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.Mvc.4.0.30506.0\lib\net40\System.Web.Mvc.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.Razor.2.0.20710.0\lib\net40\System.Web.Razor.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.WebPages.Deployment">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.EnterpriseServices" />
-    <Reference Include="TidyNet">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\TidyNet.dll</HintPath>
-    </Reference>
-    <Reference Include="umbraco, Version=1.0.5451.27172, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\umbraco.dll</HintPath>
-    </Reference>
-    <Reference Include="Umbraco.Core, Version=1.0.5451.27165, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\Umbraco.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="umbraco.DataLayer">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\umbraco.DataLayer.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="umbraco.editorControls">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\umbraco.editorControls.dll</HintPath>
-    </Reference>
-    <Reference Include="umbraco.MacroEngines">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\umbraco.MacroEngines.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="umbraco.providers">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\umbraco.providers.dll</HintPath>
-    </Reference>
-    <Reference Include="Umbraco.Web.UI">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\Umbraco.Web.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="UmbracoExamine">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\UmbracoExamine.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="UrlRewritingNet.UrlRewriter">
-      <HintPath>..\packages\UmbracoCms.Core.7.2.0\lib\UrlRewritingNet.UrlRewriter.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Converters\OpeningHoursValueConverter.cs" />

--- a/src/Our.Umbraco.OpeningHours/packages.config
+++ b/src/Our.Umbraco.OpeningHours/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoMapper" version="8.0.0" targetFramework="net472" />
-  <package id="ClientDependency" version="1.9.7" targetFramework="net472" />
-  <package id="ClientDependency-Mvc5" version="1.8.0.0" targetFramework="net472" />
+  <package id="ClientDependency" version="1.9.8" targetFramework="net472" />
+  <package id="ClientDependency-Mvc5" version="1.9.3" targetFramework="net472" />
   <package id="CSharpTest.Net.Collections" version="14.906.1403.1082" targetFramework="net472" />
-  <package id="Examine" version="1.0.0" targetFramework="net472" />
+  <package id="Examine" version="1.0.1" targetFramework="net472" />
   <package id="HtmlAgilityPack" version="1.8.14" targetFramework="net472" />
   <package id="ImageProcessor" version="2.7.0.100" targetFramework="net472" />
   <package id="LightInject" version="5.4.0" targetFramework="net472" />
@@ -44,13 +44,15 @@
   <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net472" />
   <package id="Serilog.Formatting.Compact.Reader" version="1.0.3" targetFramework="net472" />
   <package id="Serilog.Settings.AppSettings" version="2.2.2" targetFramework="net472" />
+  <package id="Serilog.Sinks.Async" version="1.3.0" targetFramework="net472" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net472" />
+  <package id="Serilog.Sinks.Map" version="1.0.0" targetFramework="net472" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net472" />
   <package id="Superpower" version="2.0.0" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net472" />
   <package id="System.Threading.Tasks.Dataflow" version="4.9.0" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="Umbraco.SqlServerCE" version="4.0.0.1" targetFramework="net472" />
-  <package id="UmbracoCms.Core" version="8.0.0" targetFramework="net472" />
-  <package id="UmbracoCms.Web" version="8.0.0" targetFramework="net472" />
+  <package id="UmbracoCms.Core" version="8.4.0" targetFramework="net472" />
+  <package id="UmbracoCms.Web" version="8.4.0" targetFramework="net472" />
 </packages>

--- a/src/Our.Umbraco.OpeningHours/packages.config
+++ b/src/Our.Umbraco.OpeningHours/packages.config
@@ -1,4 +1,56 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  
+  <package id="AutoMapper" version="8.0.0" targetFramework="net472" />
+  <package id="ClientDependency" version="1.9.7" targetFramework="net472" />
+  <package id="ClientDependency-Mvc5" version="1.8.0.0" targetFramework="net472" />
+  <package id="CSharpTest.Net.Collections" version="14.906.1403.1082" targetFramework="net472" />
+  <package id="Examine" version="1.0.0" targetFramework="net472" />
+  <package id="HtmlAgilityPack" version="1.8.14" targetFramework="net472" />
+  <package id="ImageProcessor" version="2.7.0.100" targetFramework="net472" />
+  <package id="LightInject" version="5.4.0" targetFramework="net472" />
+  <package id="LightInject.Annotation" version="1.1.0" targetFramework="net472" />
+  <package id="LightInject.Mvc" version="2.0.0" targetFramework="net472" />
+  <package id="LightInject.Web" version="2.0.0" targetFramework="net472" />
+  <package id="LightInject.WebApi" version="2.0.0" targetFramework="net472" />
+  <package id="Lucene.Net" version="3.0.3" targetFramework="net472" />
+  <package id="Markdown" version="2.2.1" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Identity.Core" version="2.2.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Identity.Owin" version="2.2.2" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.SignalR.Core" version="2.4.0" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Owin" version="4.0.1" targetFramework="net472" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="4.0.1" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security" version="4.0.1" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security.Cookies" version="4.0.1" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security.OAuth" version="4.0.1" targetFramework="net472" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
+  <package id="MiniProfiler" version="4.0.138" targetFramework="net472" />
+  <package id="MiniProfiler.Shared" version="4.0.138" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net472" />
+  <package id="NPoco" version="3.9.4" targetFramework="net472" />
+  <package id="Owin" version="1.0" targetFramework="net472" />
+  <package id="Semver" version="2.0.4" targetFramework="net472" />
+  <package id="Serilog" version="2.8.0" targetFramework="net472" />
+  <package id="Serilog.Enrichers.Process" version="2.0.1" targetFramework="net472" />
+  <package id="Serilog.Enrichers.Thread" version="3.0.0" targetFramework="net472" />
+  <package id="Serilog.Filters.Expressions" version="2.0.0" targetFramework="net472" />
+  <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net472" />
+  <package id="Serilog.Formatting.Compact.Reader" version="1.0.3" targetFramework="net472" />
+  <package id="Serilog.Settings.AppSettings" version="2.2.2" targetFramework="net472" />
+  <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net472" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net472" />
+  <package id="Superpower" version="2.0.0" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Dataflow" version="4.9.0" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
+  <package id="Umbraco.SqlServerCE" version="4.0.0.1" targetFramework="net472" />
+  <package id="UmbracoCms.Core" version="8.0.0" targetFramework="net472" />
+  <package id="UmbracoCms.Web" version="8.0.0" targetFramework="net472" />
 </packages>

--- a/src/Our.Umbraco.OpeningHours/packages.config
+++ b/src/Our.Umbraco.OpeningHours/packages.config
@@ -1,27 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="3.0.0" targetFramework="net45" developmentDependency="true" />
-  <package id="ClientDependency" version="1.8.2.1" targetFramework="net45" developmentDependency="true" />
-  <package id="ClientDependency-Mvc" version="1.8.0.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Examine" version="0.1.57.2941" targetFramework="net45" developmentDependency="true" />
-  <package id="HtmlAgilityPack" version="1.4.6" targetFramework="net45" developmentDependency="true" />
-  <package id="ImageProcessor" version="1.9.5.0" targetFramework="net45" developmentDependency="true" />
-  <package id="ImageProcessor.Web" version="3.3.1.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Lucene.Net" version="2.9.4.1" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.1" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.AspNet.Razor" version="2.0.20710.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.AspNet.WebApi" version="4.0.30506.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="4.0.30506.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="4.0.30506.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="4.0.30506.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" developmentDependency="true" />
-  <package id="MiniProfiler" version="2.1.0" targetFramework="net45" developmentDependency="true" />
-  <package id="MySql.Data" version="6.6.5" targetFramework="net45" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" developmentDependency="true" />
-  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Skybrud.Essentials" version="1.0.8" targetFramework="net45" />
-  <package id="UmbracoCms.Core" version="7.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="xmlrpcnet" version="2.5.0" targetFramework="net45" developmentDependency="true" />
+  
 </packages>


### PR DESCRIPTION
This PR adds support for Umbraco 8.4+ (since they changed the value converter-implementation I choose to go with the latest version).

We've also removed external dependencies to make the package it own "unit".

I have not updated any meta data for release/build for nuget/our.umbraco and not changed any of the markdown for readme etc. 

Let me know if you would like any changes